### PR TITLE
Monetization & Freemium plan with Stripe/Vercel setup steps and 8.x t…

### DIFF
--- a/.cursor/rules/generalrules.mdc
+++ b/.cursor/rules/generalrules.mdc
@@ -1,0 +1,29 @@
+You are my coding copilot for this project.
+
+General Rules
+1. **Stay narrow & explicit.** Implement only the features I ask for, nothing more, nothing “nice-to-have.”
+2. **Iterate one step at a time.** For each request:
+   •  Outline the plan in 1-3 sentences.  
+   •  Wait for my “👍 / go ahead” before touching code.  
+   •  After coding, show the diff or file list—then stop.
+3. **Bugs & errors.**  
+   •  If tests fail, types break, or the dev server crashes, give me a short diagnosis and ASK before fixing.  
+   •  Never open a large “solo debugging spree.”
+4. **Clarify instead of guessing.** When you’re unsure about requirements, parameters, or naming—ask.
+5. **Keep edits minimal.** No sweeping refactors, formatting churn, or library swaps unless I request them.
+6. **Docs = first-class.**  
+   •  Whenever code or build scripts change, update `PROJECT.md` / `README.md` in the same pass.  
+   •  Summarize why the change matters in ≤80 words.
+7. **No hidden files.** Don’t create extra configs, env files, or assets unless explicitly approved.
+8. **Respect project style.** Follow existing ESLint/Prettier/Tailwind conventions; TypeScript strict mode stays on.
+9. **Portable Windows build only.** No cross-platform tweaks or cloud sync features.
+10. **Commit suggestions.** End each code response with a one-line commit message (present-tense, imperative).
+
+You may use placeholders (e.g., TODO) sparingly when a user action is required. Otherwise, deliver runnable code.
+
+If any instruction from me conflicts with this prompt, **my explicit instruction wins**.
+
+If clarifying questions are necessary - end each response with concise clarifying questions for the next planned task so the user can reply ‘Ready to proceed + answers’ to minimize back-and-forth. Do not perform the next task until the user explicitly approves.
+---
+alwaysApply: true
+---

--- a/tasks/tasks-phase-2.md
+++ b/tasks/tasks-phase-2.md
@@ -1,0 +1,259 @@
+## Phase 0–5 Plan (Tailored to DanApp)
+
+This document supersedes the earlier trial model for future work. Phase 0 replaces the 7‑day trial with freemium plan gating at the API layer. Phases 1–5 expand product value and operability in sequenced steps.
+
+### Phase 0 — Switch to Freemium (foundation)
+
+#### Pricing & Plans
+- Free: 1 symbol, 3‑year max history, no exports, no alerts, watermark, rate‑limited
+- Pro: $12/mo (monthly only)
+
+#### Entitlements & Quotas (config)
+- Free: `symbols_max=1`, `history_years=3`, `alerts_max=0`, `exports=none`, `cohorts_level=none`, `watermark_on=true`
+- Pro: `symbols_max=5`, `history=full`, `alerts_max=10`, `exports=PNG,CSV,XLSX`, `cohorts_level=basic`, `watermark_on=false`
+
+#### Access Control
+- Replace time‑based trial with plan checks enforced server‑side for all data endpoints (e.g., `GET /api/returns`).
+- Add per‑account and per‑IP rate limiting; add soft device fingerprint (hashed UA+TZ+canvas) with privacy notice.
+
+#### Billing (Stripe)
+- Implement Stripe product/price: Pro (monthly only, $12). Configure automatic proration.
+- Upgrade/downgrade flows via Billing Portal; document refund policy (pro‑rata credit via Stripe defaults).
+
+### Phase 1 — Make the USP “decision‑ready”
+
+#### Percentile/Ranks
+- Compute rolling percentile for current forward‑to‑today return at horizons 1y/3y/5y.
+- UI: compact badges with tooltip showing percentile and sample size.
+
+#### Benchmark & Excess Return
+- Overlay benchmark (default SPY; user‑selectable) on the forward curve.
+- Add “excess forward return” mini‑chart (security minus benchmark).
+
+#### Distribution + Heatmap
+- Histogram of forward‑to‑today outcomes (selectable horizon).
+- Monthly start‑date heatmap; click synchronizes crosshairs on main chart.
+
+#### Drawdown/Underwater
+- Secondary chart showing drawdowns for the base‑amount series.
+
+### Phase 2 — Operability (retention makers)
+
+#### Save/Share
+- Saved Views (symbols, horizon, benchmark, toggles).
+- Permalinks with watermark for Free.
+
+#### Alerts
+- Conditions: percentile thresholds, excess return thresholds.
+- Channels: email initially; push later. Enforce quotas by plan.
+
+#### Exports
+- PNG (charts), CSV (series, stats), XLSX (existing) and zipped bundles for multi‑symbol.
+- Watermark on Free; removed for Pro.
+
+### Phase 3 — Cohorts & Presets (power value)
+
+#### Cohort Compare
+- Prebuilt groups (sectors, factors, themes) and user‑editable lists.
+- Small multiples view and summary table of current percentiles/ranks.
+
+### Phase 4 — Trust & Methodology
+
+#### Methods Page
+- Data sources; dividend/split handling; survivorship/delistings policy.
+- Exact formulas for forward‑to‑today, returns, and variance definitions.
+
+#### Auditability
+- Versioned calc notes; visible changelog surfaced in app.
+
+### Phase 5 — UX polish & Onboarding
+
+#### First‑Run Guide
+- 60‑second tour highlighting benchmark overlay, percentile badges, heatmap, and save.
+
+#### Upsell Moments
+- Lock icons and inline copy on Free features (e.g., “Add SPY overlay — Pro unlock”).
+
+---
+
+## Minimal tech spec for agent (DanApp specifics)
+
+### Data (precompute/cache)
+- Precompute and cache where possible: forward‑to‑today returns per symbol per horizon; rolling percentiles; benchmark‑aligned series; drawdowns.
+- Execution: background job via Vercel Cron for batch precomputes; on‑demand fallbacks populate cache.
+
+### Storage model (Upstash Redis keys)
+- `user:{id}`: `{ plan, stripeCustomerId?, subscriptionId?, currentPeriodEnd?, cancelAtPeriodEnd?, lastSeenAt }`
+- `entitlements:{plan}`: JSON map of plan → limits/flags
+- `saved_view:{id}` and `user:{id}:views` (ids list)
+- `alert:{id}` and `user:{id}:alerts` (ids list)
+- `fingerprint:{hash}` and counters for soft abuse controls
+- `rate:{userId}` and `rateip:{ip}` sliding windows
+- `precomp:{symbol}:{horizon}` caches for forward returns/percentiles/drawdowns
+ - Whop linkage on `user:{id}`: `billingSource?` ('stripe'|'whop'), `whopUserId?`, `whopCompanyId?`, `whopMembershipId?`, `whopAccessLinkedAt?`
+
+### APIs (Next.js routes)
+- `GET /api/returns/forward?symbol=…&horizon=…&benchmark=…`
+- `GET /api/stats/percentile?symbol=…&horizon=…`
+- `POST /api/views` / `GET /api/views`
+- `POST /api/alerts` / `PATCH /api/alerts/:id`
+- Worker/cron to evaluate alerts and send emails
+- `GET /api/export/png|csv?view_id=…` (XLSX export route remains; CSV added; PNG generated server‑side)
+- `GET /api/cohorts?name=…`
+ - Whop auth: `GET /api/auth/whop/start`, `GET /api/auth/whop/callback`
+ - Whop webhooks: `POST /api/whop/webhooks` (signature verified)
+ - Optional: `POST /api/user/link-whop` (post-login linking for existing users)
+
+### Rate limiting
+- Free: ~60 requests/hour/account and ~120/hour/IP; burst control with friendly 429 + upgrade CTA.
+- Paid: higher limits (e.g., Pro 600/hour) — configurable.
+
+### Security/Abuse
+- Soft device fingerprint: stable hash of user agent + timezone + canvas entropy; store minimal, hashed only; disclose in privacy notice.
+- Watermarking for Free exports and permalinks; watermark removed for Pro.
+
+### Billing/Stripe configuration
+- Product/Price: Pro ($12/mo).
+- Price ID via env: `STRIPE_PRICE_PRO_MONTHLY`.
+
+### Whop configuration
+- OAuth app with callback `https://<domain>/api/auth/whop/callback`.
+- Scopes for membership/company read (per Whop docs).
+- Webhook endpoint `https://<domain>/api/whop/webhooks` for membership lifecycle.
+- Env: `WHOP_CLIENT_ID`, `WHOP_CLIENT_SECRET`, `WHOP_WEBHOOK_SECRET`, and optional `WHOP_API_KEY`/`WHOP_APP_ID`.
+
+### Plan resolution precedence (Stripe vs Whop)
+- `resolvePlan(userId)` computes a single plan from external providers.
+- Precedence: if `billingSource='whop'` and Whop membership active → return Whop plan. Else if Stripe subscription active → return Stripe plan. Else `free`.
+- Divergence handling: if both are active but differ, prefer Whop; surface an admin log entry; optionally prompt user to choose one billing source in settings.
+- Deauthorization: if Whop unlinked/cancelled, automatically fall back to Stripe if present; otherwise downgrade to `free`.
+
+### Env/config (in addition to existing)
+- `RAPIDAPI_KEY` (shared provider key; server‑only)
+- `STRIPE_SECRET_KEY`, `STRIPE_PUBLISHABLE_KEY`
+- `STRIPE_PRICE_PRO_MONTHLY`
+- `STRIPE_WEBHOOK_SECRET`
+- Email provider (later): e.g., `RESEND_API_KEY` or `SENDGRID_API_KEY`
+
+---
+
+## Release order (week‑by‑week sketch)
+- Week 1 (Phase 0): Plans/entitlements live; switch to freemium; rate limits; plan gates in UI.
+- Week 2 (Phase 1a): Percentile badges + tooltips; benchmark overlay + excess mini‑chart.
+- Week 3 (Phase 1b): Histogram + heatmap; drawdown chart; performance optimizations.
+- Week 4 (Phase 2): Saved views, permalinks, PNG/CSV/XLSX exports with watermark rules.
+- Week 5 (Phase 2b): Alerts (create/list), email worker, quotas.
+- Week 6 (Phase 3): Cohorts (prebuilt + user lists) and small‑multiples.
+- Week 7 (Phase 4–5): Methods page, onboarding tour, upsell copy; polish and bugfix.
+
+### Pricing notes to implement now
+- Free hard caps: rate limit + no exports + no alerts + watermark.
+
+---
+
+## Implementation steps (ordered)
+1) Plans and entitlements
+   - Add `entitlements:{plan}` config and `user:{id}.plan` field; default all users to `free`.
+   - Add server util `getEntitlements(plan)` and `assertPlanAllows(userId, action, params)`.
+   - Replace trial gating with plan checks in all data endpoints (`/api/returns`, `/api/dividends`, exports).
+
+2) Rate limiting and device fingerprint
+   - Implement per‑account and per‑IP sliding windows with plan‑based limits.
+   - Add soft device fingerprint; deny repeated Free signups from the same device within cooling windows.
+
+3) Stripe billing
+   - Create product/price (Pro monthly only).
+   - Update Checkout creation to include plan selection.
+   - Webhook handler: update `user:{id}.plan` and Stripe metadata; handle proration, cancellations.
+   - Billing Portal endpoint for manage/cancel.
+
+4) UI gating and upsell
+   - Show plan card with Free/Pro options and a “Sign in with Whop” entry for Whop customers (bypasses Google sign‑in for Whop users).
+   - Lock icons and upsell copy on gated features; dynamic “X of Y” usage for alerts/exports.
+
+5) Data precompute jobs (Phase 1)
+   - Add Vercel Cron job for forward returns/percentiles/drawdowns; cache by `precomp:{symbol}:{horizon}`.
+   - Fallback to on‑demand compute and backfill cache on first request.
+
+6) Benchmark overlay and excess return
+   - Add benchmark selection (default SPY) and compute overlay; add excess mini‑chart.
+
+7) Distribution, heatmap, drawdown charts
+   - Implement histogram and monthly heatmap; wire crosshair sync.
+   - Add drawdown chart below main chart.
+
+8) Saved views and sharing
+   - Create `saved_view:{id}` CRUD; permalinks with watermark for Free.
+
+9) Exports
+   - Extend current XLSX export; add CSV and PNG endpoints; watermark logic by plan.
+
+10) Alerts
+   - Add create/list and worker evaluation; email sending via provider; enforce plan quotas.
+
+11) Cohorts
+   - Prebuilt cohorts + user lists; small‑multiples and summary table.
+
+12) Trust & onboarding
+   - Methods page; changelog; onboarding tour; finalize upsell copy.
+
+---
+
+## Outside-of-repo setup actions (owner checklist)
+1) DNS/Domain
+   - Choose production domain and Vercel project; note `https://<prod-domain>`.
+
+2) Whop setup
+   - Create a Whop developer account; register an App for your product.
+   - Configure OAuth with callback `https://<prod-domain>/api/auth/whop/callback`; record `WHOP_CLIENT_ID`/`WHOP_CLIENT_SECRET`.
+   - Create an Experience view URL (your in‑app page hosted on Vercel).
+   - Add webhook `https://<prod-domain>/api/whop/webhooks`; record `WHOP_WEBHOOK_SECRET`.
+   - Enable required scopes (membership/company read) and test in sandbox if available.
+
+3) Stripe setup
+   - Create Product "DanApp Pro" with Price: $12/month.
+   - Enable Checkout and Customer Portal; confirm proration settings.
+   - Add webhook `https://<prod-domain>/api/stripe/webhooks` for:
+     - `checkout.session.completed`, `customer.subscription.created`, `customer.subscription.updated`, `customer.subscription.deleted`.
+   - Record `STRIPE_SECRET_KEY`, `STRIPE_PUBLISHABLE_KEY`, `STRIPE_WEBHOOK_SECRET`, and the price ID for `STRIPE_PRICE_PRO_MONTHLY`.
+
+4) RapidAPI account
+   - Confirm plan/quota; set spend caps/alerts for the shared key.
+
+5) Vercel environment
+   - Add env vars: `RAPIDAPI_KEY`, `STRIPE_SECRET_KEY`, `STRIPE_PUBLISHABLE_KEY`, `STRIPE_PRICE_PRO_MONTHLY`, `STRIPE_WEBHOOK_SECRET`, `WHOP_CLIENT_ID`, `WHOP_CLIENT_SECRET`, `WHOP_WEBHOOK_SECRET`.
+   - Ensure existing vars: `NEXTAUTH_SECRET`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`.
+   - Redeploy to apply env changes.
+
+6) Monitoring & QA
+   - Test Whop OAuth and webhook flows (purchase/cancel) to verify `user.plan` updates.
+   - Test Stripe Checkout and webhook flows; verify plan transitions.
+   - Validate rate limits and access gates with Free vs Pro users.
+
+## Task list (to be executed in order)
+- [ ] P0.1 Add entitlements config and `user:{id}.plan` default `free`
+- [ ] P0.2 Implement `assertPlanAllows` and replace trial gating everywhere
+- [ ] P0.3 Implement per‑account/IP rate limiting; add soft device fingerprint
+- [ ] P0.4 Stripe: product/price (Pro monthly only)
+- [ ] P0.5 Checkout/Portal endpoints; webhook → `user.plan` transitions
+- [ ] P0.6 UI plan cards and upsell; remove trial messaging
+- [ ] P0.7 Docs: README/PROJECT envs and pricing plans
+- [ ] P0.W1 Add Whop env/config (OAuth + webhooks)
+- [ ] P0.W2 Implement Whop OAuth start/callback; create/link user; bypass Google for Whop users
+- [ ] P0.W3 Implement `/api/whop/webhooks` with signature verification; update `user.plan`
+- [ ] P0.W4 Update `resolvePlan` to check `billingSource` ('whop' first, else 'stripe')
+- [ ] P0.W5 UI: Add “Sign in with Whop” and “Manage on Whop” if `billingSource='whop'`
+- [ ] P0.W6 Docs: Add Whop setup steps to README/PROJECT
+- [ ] P1.1 Precompute job for forward returns/percentiles/drawdowns (cron + on‑demand)
+- [ ] P1.2 Percentile badges + tooltips; sample size
+- [ ] P1.3 Benchmark overlay (default SPY) and excess mini‑chart
+- [ ] P1.4 Histogram + monthly heatmap with crosshair sync
+- [ ] P1.5 Drawdown chart for base‑amount series
+- [ ] P2.1 Saved views CRUD and permalinks with watermarking rules
+- [ ] P2.2 Exports: CSV + PNG endpoints; extend XLSX; plan gating
+- [ ] P2.3 Alerts: API + worker + email provider; enforce quotas
+- [ ] P3.1 Cohorts: prebuilt + user lists; small‑multiples view
+- [ ] P4.1 Methods page + auditability notes surfaced in app
+- [ ] P5.1 Onboarding tour and targeted upsell copy
+
+---

--- a/tasks/tasks-project_markdown.md
+++ b/tasks/tasks-project_markdown.md
@@ -17,6 +17,7 @@
 - `tasks/tasks-project_markdown.md` — Updated to mark task 4.1 complete and list relevant files
 ### Notes
 2 charts - the one showing the thing and another being normal
+front page should later make it known of the 1 week trial
 
 
 ## Tasks
@@ -72,3 +73,97 @@
   - [ ] 7.5 Confirm monitoring via Vercel logs; optionally wire Sentry DSN.
 
 
+
+## Monetization and Freemium
+
+### Decision summary
+- Stripe Checkout + Billing Portal; single monthly price with 7-day free trial.
+- No card required to start trial; price: $7.50 USD/month.
+- Keep Google-only sign-in; rely on Google `email_verified`.
+- Replace per-user RapidAPI keys with one server-managed `RAPIDAPI_KEY`.
+- Auto-start trial on first sign-in and clearly message on/around the front page.
+- Soft anti-abuse: per-user and per-IP rate limits; device cookie; optional CAPTCHA on spikes.
+
+### Why this matters (≤80 words)
+Removes user friction of supplying keys, enables predictable costs via a single platform key, and introduces revenue with a simple 7‑day free trial then subscription. Server-side gating prevents client leaks and supports soft abuse controls. Stripe Checkout/Portal keeps payment UX secure and offsite. This change aligns the product with a sustainable freemium model while preserving existing charts and workflows.
+
+### Access model and statuses
+- Statuses: `trialing` (until `trialEndsAt`), `active` (Stripe subscription), `expired` (trial ended or subscription inactive).
+- Gating: All data endpoints (e.g., `GET /api/returns`) call a server util `assertAccessAllowed(userId)` to allow only `trialing` or `active`.
+- Rate limits: `trialing` 30 rpm/user; `active` 120 rpm/user; global per-IP soft caps.
+
+### Data stored (Redis)
+- `user:{id}`: `trialStartedAt`, `trialEndsAt`, `status`, `stripeCustomerId`, `subscriptionId`, `currentPeriodEnd`, `cancelAtPeriodEnd`, `lastSeenAt`.
+- `abuse:{ip}` and `abuse:{deviceId}` counters for soft abuse prevention.
+
+### Endpoints and server updates
+- Add `POST /api/billing/checkout` → returns Stripe Checkout URL for subscription.
+- Add `POST /api/billing/portal` → returns Stripe Billing Portal URL.
+- Add `POST /api/stripe/webhooks` → handle `checkout.session.completed`, `customer.subscription.created|updated|deleted` and update user status.
+- Add `GET /api/user/status` → `{ status, trialEndsAt, currentPeriodEnd, canAccess }`.
+- Update existing `GET /api/*` to call `assertAccessAllowed(userId)`.
+- Remove `/api/user/key` endpoints (no longer needed).
+
+### UI updates
+- Replace `KeyModal` with a lightweight Access panel:
+  - Trialing: show days remaining and a “Subscribe” button (to Checkout).
+  - Active: show a “Manage billing” button (to Billing Portal).
+  - Expired: show “Subscribe to continue”.
+- Front page: pre-sign-in note that a 7‑day free trial starts on first sign-in.
+
+### Env/config additions
+- `RAPIDAPI_KEY` (shared provider key; server-only).
+- `STRIPE_SECRET_KEY`, `STRIPE_PUBLISHABLE_KEY`.
+- `STRIPE_PRICE_ID` (monthly $7.50; currency `usd`).
+- `STRIPE_WEBHOOK_SECRET`.
+
+### Outside-of-repo setup (owner actions)
+1) Stripe (test mode first)
+   - Create Stripe account and enable Billing/Checkout.
+   - Create Product (e.g., “DanApp Pro”) and recurring Price: $7.50 USD/month.
+   - Ensure Price has a 7-day free trial (no card required to start).
+   - In Developers → API keys: copy Secret and Publishable keys.
+   - In Developers → Webhooks: add endpoint `https://your-vercel-domain.com/api/stripe/webhooks` with events:
+     - `checkout.session.completed`, `customer.subscription.created`, `customer.subscription.updated`, `customer.subscription.deleted`.
+   - Copy the webhook signing secret.
+   - Configure Billing Portal (Business settings → Customer portal) and allow plan cancel/manage.
+
+2) Vercel environment
+   - Set env vars on the project: `RAPIDAPI_KEY`, `STRIPE_SECRET_KEY`, `STRIPE_PUBLISHABLE_KEY`, `STRIPE_PRICE_ID`, `STRIPE_WEBHOOK_SECRET`.
+   - Ensure existing vars remain set: `NEXTAUTH_SECRET`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`.
+   - Redeploy to apply env changes.
+
+3) RapidAPI plan
+   - Ensure the account plan supports expected paid usage; monitor quotas and cost caps.
+
+4) DNS/URLs
+   - Decide on production domain; update Stripe webhook URL if domain changes.
+
+5) Monitoring
+   - Watch Vercel logs and Stripe dashboard events when enabling live mode.
+
+### Implementation steps (sequenced)
+1. Server: add `assertAccessAllowed(userId)` and trial initializer on first authenticated hit.
+2. Server: add `GET /api/user/status`.
+3. Server: implement Stripe Checkout/Portal endpoints.
+4. Server: implement Stripe webhook handler and status transitions.
+5. Server: swap data providers to use shared `RAPIDAPI_KEY` only.
+6. Server: remove `/api/user/key` routes and related code; purge stored user keys.
+7. UI: add Access panel and pre-sign-in trial messaging; remove `KeyModal`.
+8. Gating: apply `assertAccessAllowed` in `GET /api/returns` (and related routes).
+9. Rate limits: parameterize by status and add per-IP counters + device cookie.
+10. Docs: update `README.md` with env/Stripe steps and note the freemium model.
+
+---
+
+- [ ] 8.0 Monetization and billing
+  - [ ] 8.1 Remove per-user key flow: delete `/api/user/key` and `KeyModal`; purge `user:{id}:rapidapiKey`.
+  - [ ] 8.2 Inject shared `RAPIDAPI_KEY` in providers; never expose to client.
+  - [ ] 8.3 Add trial init on first sign-in; store `trialStartedAt` and `trialEndsAt` (+7 days).
+  - [ ] 8.4 Implement `assertAccessAllowed(userId)` and gate `GET /api/returns` (etc.).
+  - [ ] 8.5 Add `POST /api/billing/checkout` and `POST /api/billing/portal`.
+  - [ ] 8.6 Add `POST /api/stripe/webhooks` with subscription lifecycle handling.
+  - [ ] 8.7 Add `GET /api/user/status` for client UI.
+  - [ ] 8.8 UI: Access panel + pre-sign-in trial message; remove key UI.
+  - [ ] 8.9 Rate limits: 30 rpm trial, 120 rpm paid; per-IP soft caps; device cookie.
+  - [ ] 8.10 Docs: update `README.md` and `PROJECT.md` with envs and setup.


### PR DESCRIPTION
…asks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a detailed Monetization/Freemium plan to `tasks/tasks-project_markdown.md` outlining Stripe-based billing, access gating, required endpoints, UI updates, env vars, owner setup, and an 8.x implementation checklist.
> 
> - **Docs/Planning** (`tasks/tasks-project_markdown.md`):
>   - **Monetization & Freemium model**: Stripe Checkout + Billing Portal; 7‑day trial; shared `RAPIDAPI_KEY`; access statuses `trialing|active|expired`; rate limits per status.
>   - **Server**:
>     - Endpoints: `POST /api/billing/checkout`, `POST /api/billing/portal`, `POST /api/stripe/webhooks`, `GET /api/user/status`.
>     - Gating: `assertAccessAllowed(userId)` applied to `GET /api/*`; remove `/api/user/key` routes.
>   - **UI**:
>     - Replace `KeyModal` with Access panel; trial/active/expired states; front-page trial messaging.
>   - **Env/config**: `RAPIDAPI_KEY`, `STRIPE_SECRET_KEY`, `STRIPE_PUBLISHABLE_KEY`, `STRIPE_PRICE_ID`, `STRIPE_WEBHOOK_SECRET`.
>   - **Owner setup**: Stripe products/webhook/portal config; Vercel env vars; RapidAPI plan; DNS; monitoring.
>   - **Implementation steps**: Sequenced server/UI changes and new **8.x Monetization and billing** checklist.
>   - Minor note: call out 1‑week trial on front page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 235e986fec9956d04cc6596a73d55e1f7387be4b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->